### PR TITLE
add tax calculation services for different item types

### DIFF
--- a/src/main/java/org/example/constants/TaxRateConstants.java
+++ b/src/main/java/org/example/constants/TaxRateConstants.java
@@ -1,0 +1,10 @@
+package org.example.constants;
+
+public class TaxRateConstants {
+  public static final double BASE_TAX_RATE = 0.125;
+  public static final double MANUFACTURED_SURCHARGE_RATE = 0.02;
+  public static final double IMPORT_DUTY_RATE = 0.10;
+  public static final double SURCHARGE_LOW = 5;
+  public static final double SURCHARGE_MEDIUM = 10;
+  public static final double SURCHARGE_HIGH_RATE = 0.05;
+}

--- a/src/main/java/org/example/factories/ImportedItemTaxFactory.java
+++ b/src/main/java/org/example/factories/ImportedItemTaxFactory.java
@@ -1,0 +1,11 @@
+package org.example.factories;
+
+import org.example.services.ImportedItemTaxService;
+import org.example.services.TaxCalculationInterface;
+
+public class ImportedItemTaxFactory implements TaxServiceFactory {
+  @Override
+  public TaxCalculationInterface createTaxService() {
+    return new ImportedItemTaxService();
+  }
+}

--- a/src/main/java/org/example/factories/ManufacturedItemTaxFactory.java
+++ b/src/main/java/org/example/factories/ManufacturedItemTaxFactory.java
@@ -1,0 +1,11 @@
+package org.example.factories;
+
+import org.example.services.ManufacturedItemTaxService;
+import org.example.services.TaxCalculationInterface;
+
+public class ManufacturedItemTaxFactory implements TaxServiceFactory {
+  @Override
+  public TaxCalculationInterface createTaxService() {
+    return new ManufacturedItemTaxService();
+  }
+}

--- a/src/main/java/org/example/factories/RawItemTaxFactory.java
+++ b/src/main/java/org/example/factories/RawItemTaxFactory.java
@@ -1,0 +1,11 @@
+package org.example.factories;
+
+import org.example.services.RawItemTaxService;
+import org.example.services.TaxCalculationInterface;
+
+public class RawItemTaxFactory implements TaxServiceFactory {
+  @Override
+  public TaxCalculationInterface createTaxService() {
+    return new RawItemTaxService();
+  }
+}

--- a/src/main/java/org/example/factories/TaxServiceFactory.java
+++ b/src/main/java/org/example/factories/TaxServiceFactory.java
@@ -1,0 +1,7 @@
+package org.example.factories;
+
+import org.example.services.TaxCalculationInterface;
+
+public interface TaxServiceFactory {
+  TaxCalculationInterface createTaxService();
+}

--- a/src/main/java/org/example/services/ImportedItemTaxService.java
+++ b/src/main/java/org/example/services/ImportedItemTaxService.java
@@ -1,0 +1,26 @@
+package org.example.services;
+
+import org.example.constants.TaxRateConstants;
+
+public class ImportedItemTaxService implements TaxCalculationInterface {
+  @Override
+  public final double calculate(final double price) {
+    if (price <= 0) {
+      throw new IllegalArgumentException("Price should be a positive real number greater than "
+          + "zero");
+    }
+    final double importDuty = price * TaxRateConstants.IMPORT_DUTY_RATE;
+    final double surcharge = calculateSurcharge(price + importDuty);
+    return importDuty + surcharge;
+  }
+
+  private static double calculateSurcharge(final double costAfterTax) {
+    if (costAfterTax <= 100) {
+      return TaxRateConstants.SURCHARGE_LOW;
+    } else if (costAfterTax <= 200) {
+      return TaxRateConstants.SURCHARGE_MEDIUM;
+    } else {
+      return costAfterTax * TaxRateConstants.SURCHARGE_HIGH_RATE;
+    }
+  }
+}

--- a/src/main/java/org/example/services/ManufacturedItemTaxService.java
+++ b/src/main/java/org/example/services/ManufacturedItemTaxService.java
@@ -1,0 +1,16 @@
+package org.example.services;
+
+import org.example.constants.TaxRateConstants;
+
+public class ManufacturedItemTaxService implements TaxCalculationInterface {
+  @Override
+  public final double calculate(final double price) {
+    if (price <= 0) {
+      throw new IllegalArgumentException("Price should be a positive real number greater than "
+          + "zero");
+    }
+    return price * TaxRateConstants.BASE_TAX_RATE
+        + (price * (1 + TaxRateConstants.BASE_TAX_RATE))
+        * TaxRateConstants.MANUFACTURED_SURCHARGE_RATE;
+  }
+}

--- a/src/main/java/org/example/services/RawItemTaxService.java
+++ b/src/main/java/org/example/services/RawItemTaxService.java
@@ -1,0 +1,14 @@
+package org.example.services;
+
+import org.example.constants.TaxRateConstants;
+
+public class RawItemTaxService implements TaxCalculationInterface {
+  @Override
+  public final double calculate(final double price) {
+    if (price <= 0) {
+      throw new IllegalArgumentException("Price should be a positive real number greater than "
+          + "zero");
+    }
+    return price * TaxRateConstants.BASE_TAX_RATE;
+  }
+}

--- a/src/main/java/org/example/services/TaxCalculationInterface.java
+++ b/src/main/java/org/example/services/TaxCalculationInterface.java
@@ -1,0 +1,5 @@
+package org.example.services;
+
+public interface TaxCalculationInterface {
+  double calculate(final double price);
+}

--- a/src/main/java/org/example/services/TaxCalculatorService.java
+++ b/src/main/java/org/example/services/TaxCalculatorService.java
@@ -1,0 +1,31 @@
+package org.example.services;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.example.enums.ItemType;
+
+public class TaxCalculatorService implements TaxCalculatorServiceInterface {
+
+  private final Map<ItemType, TaxCalculationInterface> taxStrategyMap;
+
+  public TaxCalculatorService() {
+    taxStrategyMap = new HashMap<>();
+    taxStrategyMap.put(ItemType.RAW, new RawItemTaxService());
+    taxStrategyMap.put(ItemType.MANUFACTURED, new ManufacturedItemTaxService());
+    taxStrategyMap.put(ItemType.IMPORTED, new ImportedItemTaxService());
+  }
+
+  @Override
+  public final double calculateTax(final ItemType type, final Double price) {
+    if (price == null || price < 0) {
+      throw new IllegalArgumentException("Price must be a non-null, non-negative value.");
+    }
+
+    final TaxCalculationInterface strategy = taxStrategyMap.get(type);
+    if (strategy == null) {
+      throw new IllegalArgumentException("Unsupported item type: " + type);
+    }
+
+    return strategy.calculate(price);
+  }
+}

--- a/src/main/java/org/example/services/TaxCalculatorService.java
+++ b/src/main/java/org/example/services/TaxCalculatorService.java
@@ -3,16 +3,20 @@ package org.example.services;
 import java.util.HashMap;
 import java.util.Map;
 import org.example.enums.ItemType;
+import org.example.factories.ImportedItemTaxFactory;
+import org.example.factories.ManufacturedItemTaxFactory;
+import org.example.factories.RawItemTaxFactory;
+import org.example.factories.TaxServiceFactory;
 
 public class TaxCalculatorService implements TaxCalculatorServiceInterface {
 
-  private final Map<ItemType, TaxCalculationInterface> taxStrategyMap;
+  private final Map<ItemType, TaxServiceFactory> taxFactoryMap;
 
   public TaxCalculatorService() {
-    taxStrategyMap = new HashMap<>();
-    taxStrategyMap.put(ItemType.RAW, new RawItemTaxService());
-    taxStrategyMap.put(ItemType.MANUFACTURED, new ManufacturedItemTaxService());
-    taxStrategyMap.put(ItemType.IMPORTED, new ImportedItemTaxService());
+    taxFactoryMap = new HashMap<>();
+    taxFactoryMap.put(ItemType.RAW, new RawItemTaxFactory());
+    taxFactoryMap.put(ItemType.MANUFACTURED, new ManufacturedItemTaxFactory());
+    taxFactoryMap.put(ItemType.IMPORTED, new ImportedItemTaxFactory());
   }
 
   @Override
@@ -21,11 +25,12 @@ public class TaxCalculatorService implements TaxCalculatorServiceInterface {
       throw new IllegalArgumentException("Price must be a non-null, non-negative value.");
     }
 
-    final TaxCalculationInterface strategy = taxStrategyMap.get(type);
-    if (strategy == null) {
+    final TaxServiceFactory factory = taxFactoryMap.get(type);
+    if (factory == null) {
       throw new IllegalArgumentException("Unsupported item type: " + type);
     }
 
-    return strategy.calculate(price);
+    final TaxCalculationInterface taxService = factory.createTaxService();
+    return taxService.calculate(price);
   }
 }

--- a/src/main/java/org/example/services/TaxCalculatorServiceInterface.java
+++ b/src/main/java/org/example/services/TaxCalculatorServiceInterface.java
@@ -1,0 +1,7 @@
+package org.example.services;
+
+import org.example.enums.ItemType;
+
+public interface TaxCalculatorServiceInterface {
+  double calculateTax(final ItemType type, final Double price);
+}

--- a/src/test/java/services/ImportedItemTaxServiceTest.java
+++ b/src/test/java/services/ImportedItemTaxServiceTest.java
@@ -1,0 +1,63 @@
+package services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.example.constants.TaxRateConstants;
+import org.example.services.ImportedItemTaxService;
+import org.junit.jupiter.api.Test;
+
+public class ImportedItemTaxServiceTest {
+
+  private final ImportedItemTaxService service = new ImportedItemTaxService();
+
+  @Test
+  public final void testCalculateTaxForLowCost() {
+    final double price = 80.0;
+    final double importDuty = price * TaxRateConstants.IMPORT_DUTY_RATE;
+    final double expectedTax = importDuty + TaxRateConstants.SURCHARGE_LOW;
+    final double actualTax = service.calculate(price);
+    assertEquals(expectedTax, actualTax);
+  }
+
+  @Test
+  public final void testCalculateTaxForMediumCost() {
+    final double price = 150.0;
+    final double importDuty = price * TaxRateConstants.IMPORT_DUTY_RATE;
+    final double expectedTax = importDuty + TaxRateConstants.SURCHARGE_MEDIUM;
+    final double actualTax = service.calculate(price);
+    assertEquals(expectedTax, actualTax);
+  }
+
+  @Test
+  public final void testCalculateTaxForHighCost() {
+    final double price = 250.0;
+    final double importDuty = price * TaxRateConstants.IMPORT_DUTY_RATE;
+    final double surcharge = (price + importDuty) * TaxRateConstants.SURCHARGE_HIGH_RATE;
+    final double expectedTax = importDuty + surcharge;
+    final double actualTax = service.calculate(price);
+    assertEquals(expectedTax, actualTax);
+  }
+
+  @Test
+  public final void testCalculateTaxForZeroPrice() {
+    final double price = 0.0;
+    assertThrows(IllegalArgumentException.class, () -> service.calculate(price));
+  }
+
+  @Test
+  public final void testCalculateTaxForNegativePrice() {
+    final double price = -50.0;
+    assertThrows(IllegalArgumentException.class, () -> service.calculate(price));
+  }
+
+  @Test
+  public final void testCalculateTaxForMaxDoubleValue() {
+    final double price = Double.MAX_VALUE;
+    final double importDuty = price * TaxRateConstants.IMPORT_DUTY_RATE;
+    final double surcharge = (price + importDuty) * TaxRateConstants.SURCHARGE_HIGH_RATE;
+    final double expectedTax = importDuty + surcharge;
+    final double actualTax = service.calculate(price);
+    assertEquals(expectedTax, actualTax);
+  }
+}

--- a/src/test/java/services/ManufacturedItemTaxServiceTest.java
+++ b/src/test/java/services/ManufacturedItemTaxServiceTest.java
@@ -1,0 +1,45 @@
+package services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.example.constants.TaxRateConstants;
+import org.example.services.ManufacturedItemTaxService;
+import org.junit.jupiter.api.Test;
+
+public class ManufacturedItemTaxServiceTest {
+
+  private final ManufacturedItemTaxService service = new ManufacturedItemTaxService();
+
+  @Test
+  public final void testCalculateTaxForNormalPrice() {
+    final double price = 100.0;
+    final double expectedTax = price * TaxRateConstants.BASE_TAX_RATE
+        + (price * (1 + TaxRateConstants.BASE_TAX_RATE))
+        * TaxRateConstants.MANUFACTURED_SURCHARGE_RATE;
+    final double actualTax = service.calculate(price);
+    assertEquals(expectedTax, actualTax);
+  }
+
+  @Test
+  public final void testCalculateTaxForZeroPrice() {
+    final double price = 0.0;
+    assertThrows(IllegalArgumentException.class, () -> service.calculate(price));
+  }
+
+  @Test
+  public final void testCalculateTaxForNegativePrice() {
+    final double price = -50.0;
+    assertThrows(IllegalArgumentException.class, () -> service.calculate(price));
+  }
+
+  @Test
+  public final void testCalculateTaxForMaxDoubleValue() {
+    final double price = Double.MAX_VALUE;
+    final double expectedTax = price * TaxRateConstants.BASE_TAX_RATE
+        + (price * (1 + TaxRateConstants.BASE_TAX_RATE))
+        * TaxRateConstants.MANUFACTURED_SURCHARGE_RATE;
+    final double actualTax = service.calculate(price);
+    assertEquals(expectedTax, actualTax);
+  }
+}

--- a/src/test/java/services/RawItemTaxServiceTest.java
+++ b/src/test/java/services/RawItemTaxServiceTest.java
@@ -1,0 +1,41 @@
+package services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.example.constants.TaxRateConstants;
+import org.example.services.RawItemTaxService;
+import org.junit.jupiter.api.Test;
+
+public class RawItemTaxServiceTest {
+
+  private final RawItemTaxService service = new RawItemTaxService();
+
+  @Test
+  public final void testCalculateTaxForNormalPrice() {
+    final double price = 100.0;
+    final double expectedTax = price * TaxRateConstants.BASE_TAX_RATE;
+    final double actualTax = service.calculate(price);
+    assertEquals(expectedTax, actualTax);
+  }
+
+  @Test
+  public final void testCalculateTaxForZeroPrice() {
+    final double price = 0.0;
+    assertThrows(IllegalArgumentException.class, () -> service.calculate(price));
+  }
+
+  @Test
+  public final void testCalculateTaxForNegativePrice() {
+    final double price = -50.0;
+    assertThrows(IllegalArgumentException.class, () -> service.calculate(price));
+  }
+
+  @Test
+  public final void testCalculateTaxForMaxDoubleValue() {
+    final double price = Double.MAX_VALUE;
+    final double expectedTax = price * TaxRateConstants.BASE_TAX_RATE;
+    final double actualTax = service.calculate(price);
+    assertEquals(expectedTax, actualTax);
+  }
+}

--- a/src/test/java/services/TaxCalculatorServiceTest.java
+++ b/src/test/java/services/TaxCalculatorServiceTest.java
@@ -1,0 +1,78 @@
+package services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.example.enums.ItemType;
+import org.example.services.TaxCalculatorService;
+import org.junit.jupiter.api.Test;
+
+public class TaxCalculatorServiceTest {
+
+  private final TaxCalculatorService taxCalculatorService = new TaxCalculatorService();
+
+  @Test
+  public final void testCalculateTaxRawItem() {
+    final double price = 100.0;
+    final double expectedTax = 12.5; // 12.5% of 100.0
+    final double actualTax = taxCalculatorService.calculateTax(ItemType.RAW, price);
+    assertEquals(expectedTax, actualTax);
+  }
+
+  @Test
+  public final void testCalculateTaxManufacturedItem() {
+    final double price = 100.0;
+    final double expectedTax = 14.75; // 12.5% of 100.0 + 2% of (100.0 + 12.5)
+    final double actualTax = taxCalculatorService.calculateTax(ItemType.MANUFACTURED, price);
+    assertEquals(expectedTax, actualTax);
+  }
+
+  @Test
+  public final void testCalculateTaxImportedItem() {
+    final double price = 100.0;
+    final double expectedTax = 10.0 + 10.0; // 10% of 100.0 + surcharge Rs. 10 (final cost <= 200)
+    final double actualTax = taxCalculatorService.calculateTax(ItemType.IMPORTED, price);
+    assertEquals(expectedTax, actualTax);
+  }
+
+  @Test
+  public final void testCalculateTaxImportedMediumSurcharge() {
+    final double price = 150.0;
+    final double expectedTax = 15.0 + 10.0; // 10% of 150.0 + surcharge Rs. 10 (100 < final cost <= 200)
+    final double actualTax = taxCalculatorService.calculateTax(ItemType.IMPORTED, price);
+    assertEquals(expectedTax, actualTax);
+  }
+
+  @Test
+  public final void testCalculateTaxImportedHighSurcharge() {
+    final double price = 250.0;
+    final double finalCost = price + (price * 0.10); // Price + 10% import duty
+    final double expectedTax = (price * 0.10) + (finalCost * 0.05); // 10% import duty + 5% surcharge
+    final double actualTax = taxCalculatorService.calculateTax(ItemType.IMPORTED, price);
+    assertEquals(expectedTax, actualTax);
+  }
+
+  @Test
+  public final void testCalculateTaxWithNullPrice() {
+    assertThrows(IllegalArgumentException.class,
+        () -> taxCalculatorService.calculateTax(ItemType.RAW, null));
+  }
+
+  @Test
+  public final void testCalculateTaxWithNegativePrice() {
+    assertThrows(IllegalArgumentException.class,
+        () -> taxCalculatorService.calculateTax(ItemType.RAW, -10.0));
+  }
+
+  @Test
+  public final void testCalculateTaxWithUnsupportedItemType() {
+    assertThrows(IllegalArgumentException.class,
+        () -> taxCalculatorService.calculateTax(null, 100.0));
+  }
+
+  @Test
+  public final void testCalculateTaxWithInvalidItemType() {
+    assertThrows(IllegalArgumentException.class,
+        () -> taxCalculatorService.calculateTax(ItemType.valueOf("INVALID_TYPE"), 100.0));
+  }
+}


### PR DESCRIPTION
## What?

- Added TaxRateConstants for centralizing tax-related constants.
- Implemented tax calculation services (RawItemTaxService, ManufacturedItemTaxService, ImportedItemTaxService) with validation and custom logic.
- Developed TaxCalculatorService for item-specific tax calculation based on type.
- Created unit tests for all tax calculation services and the TaxCalculatorService.

## Why?

- To encapsulate tax calculation logic and ensure consistent application across different item types.

## Impact?

- Affects tax calculation logic for items; no other services impacted.

## Testing?

- Unit tests executed and passed for all tax services and TaxCalculatorService.
- Achieved 100% code coverage (excluding the constants package).
## Test Cases
- [Test Cases](https://docs.google.com/document/d/11HZzmyvi2LyLxuKWSjHhxNCYnQJ6KEdpzXG5xRPN0QI/edit)
## Design Patterns Followed ( changed strategy pattern to Abstract factory pattern ) :
- Strategy Pattern: Used in TaxCalculatorService for dynamic selection of tax calculation strategy based on item type.
- Command Pattern: Each tax service acts as a command object, with TaxCalculatorService invoking the appropriate command.
- Constant Class Pattern: Used in TaxRateConstants for managing tax-related constants.

## Checklist:

- [x]  I have self-reviewed the PR.
- [x]  I am aware of the impact of the changes on services.
- [x]  I have verified that all relevant tests are included and have passed.


## Implemented the Abstract Factory pattern to improve the design. This change:

- Increases flexibility by allowing easy addition of new tax calculation types.
- Makes testing easy by allowing easy substitution of components.
- Ensures consistency in creating related objects.
- These improvements make the code more scalable and easier to extend in the future.